### PR TITLE
ci: Update Dagger version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Dagger -> test-405
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-
@@ -39,7 +39,7 @@ jobs:
       - name: Dagger -> test-200
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-
@@ -62,7 +62,7 @@ jobs:
       - name: Dagger -> build
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Dagger -> build
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-
@@ -51,7 +51,7 @@ jobs:
       - name: Dagger -> test-405
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-
@@ -64,7 +64,7 @@ jobs:
       - name: Dagger -> test-200
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Dagger -> test-405
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-
@@ -48,7 +48,7 @@ jobs:
       - name: Dagger -> test-200
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-
@@ -90,7 +90,7 @@ jobs:
       - name: Dagger -> build
         uses: dagger/dagger-for-github@v7
         with:
-          version: "v0.15.3"
+          version: "v0.18.9"
           verb: call
           # FIXME: this is a workaround for https://github.com/dagger/dagger-for-github/issues/117
           args: >-


### PR DESCRIPTION
Upgrade the Dagger version used in the GitHub Actions workflow from v0.15.3 to v0.18.9 to resolve a GitHub Action error.